### PR TITLE
Correct typo in function name

### DIFF
--- a/R/github_release.R
+++ b/R/github_release.R
@@ -69,7 +69,7 @@ github_release_create <- function(info, description=NULL,
 
   dat <- github_release_package_info(info, target)
 
-  github_release_create1(info, dat, filename, version, description,
+  github_release_create_(info, dat, filename, version, description,
                          ignore_dirty, yes)
 }
 


### PR DESCRIPTION
I believe there is a small typo here. Correcting it seemed to make `github_release_create` work as expected
